### PR TITLE
feat: :construction: adjust the endpoint and the cli command dependencies

### DIFF
--- a/adapters/api/server.go
+++ b/adapters/api/server.go
@@ -4,25 +4,27 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"strconv"
 
 	"github.com/wy7-source/iti-challenge/adapters/dto"
-	"github.com/wy7-source/iti-challenge/application"
+	"github.com/wy7-source/iti-challenge/application/domain"
 )
 
 type Server struct {
-	Port string
+	Port            string
+	PasswordService domain.PasswordServiceInterface
 }
 
-func MakeServer(port string) *Server {
-	return &Server{Port: port}
+func MakeServer(port string, passwordService domain.PasswordServiceInterface) *Server {
+	return &Server{Port: port, PasswordService: passwordService}
 }
 
 func (s Server) ValidateHandler(w http.ResponseWriter, r *http.Request) {
 	// Call service, that call Pasword Type and Validate, than return response here.
-	var password application.Password
+	var password domain.Password
 	var passwordReceived dto.PasswordDto
-	err := json.NewDecoder(r.Body).Decode(&passwordReceived)
 
+	err := json.NewDecoder(r.Body).Decode(&passwordReceived)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write(responseFormater(err.Error()))
@@ -30,15 +32,14 @@ func (s Server) ValidateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err = passwordReceived.Hydrate(&password)
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("false"))
-		return
-	} else {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("true"))
+		w.Write(responseFormater("false"))
+		return
 	}
-}
 
+	result := s.PasswordService.Validate(&password)
+	w.Write(responseFormater(strconv.FormatBool(result)))
+}
 func (s Server) Serve() {
 	http.HandleFunc("/validate", s.ValidateHandler)
 	log.Fatal(http.ListenAndServe(s.Port, nil))

--- a/adapters/cmd/api.go
+++ b/adapters/cmd/api.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	server "github.com/wy7-source/iti-challenge/adapters/api"
+	"github.com/wy7-source/iti-challenge/application/services"
 )
 
 var port string
@@ -28,7 +29,8 @@ var apiCmd = &cobra.Command{
 	Short: "Api is the way to interact with application.",
 	Long:  `Api enable the '/validate' endpoint, that can receive a json with password to be validated.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		server := server.MakeServer(port)
+		passwordService := services.NewPasswordService()
+		server := server.MakeServer(port, passwordService)
 		server.Serve()
 	},
 }


### PR DESCRIPTION
# Description

That change are made because now we can use a service to validate the password.

# How Has This Been Tested?

I made integration tests by humao.rest-client on vscode.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] The Dockerfile still build sucessfully
- [x] The Unit Tests Still passing sucessfully
